### PR TITLE
Fix mobile card height

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,6 +257,7 @@
             display: -webkit-box;
             -webkit-box-orient: vertical;
             -webkit-line-clamp: 3;
+            line-clamp: 3;
             overflow: hidden;
         }
 
@@ -617,6 +618,12 @@
         ]).then(() => {
             syncCarousels();
             // force-run our height-equaliser immediately
+            equaliseCardHeights(menuGrid);
+            equaliseCardHeights(eventGrid);
+        });
+
+        /* ensure heights are correct after all images load */
+        window.addEventListener('load', () => {
             equaliseCardHeights(menuGrid);
             equaliseCardHeights(eventGrid);
         });


### PR DESCRIPTION
## Summary
- clamp long card descriptions with `line-clamp: 3` for browsers that support it
- ensure card heights equalise once all images have loaded

## Testing
- `tidy -q -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_688aeab244ac83328655cccdfac76fd1