### PR TITLE
feat: add gallery carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,59 @@
             object-fit: cover;
             border-radius: .5rem;
         }
+
+        /* ===== Gallery carousel (Flickity) ===== */
+        .gallery-carousel {
+            /* Flickity will add .flickity-enabled */
+        }
+        .gallery-carousel .carousel-cell {
+            width: 80%;
+            margin: 0 .75rem;
+        }
+        .gallery-carousel .carousel-cell a {
+            display: block;
+            overflow: hidden;
+            border-radius: .5rem;
+        }
+        .gallery-carousel .carousel-cell img {
+            display: block;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        .gallery-carousel .flickity-page-dots {
+            margin-top: 1rem;
+        }
+        .gallery-carousel .flickity-page-dots .dot {
+            width: 8px;
+            height: 8px;
+            margin: 0 4px;
+            opacity: .4;
+        }
+        .gallery-carousel .flickity-page-dots .dot.is-selected {
+            opacity: 1;
+        }
+
+        /* Tablet: 2-up */
+        @media (min-width: 576px) {
+            .gallery-carousel .carousel-cell {
+                width: 45%;
+            }
+        }
+
+        /* Desktop: 3-up */
+        @media (min-width: 992px) {
+            .gallery-carousel .carousel-cell {
+                width: 30%;
+            }
+        }
+
+        /* Large desktop: a bit tighter if desired */
+        @media (min-width: 1200px) {
+            .gallery-carousel .carousel-cell {
+                width: 28%;
+            }
+        }
     </style>
 </head>
 
@@ -349,25 +402,10 @@
     <!-- =================================================
   GALLERY
 ================================================= -->
-    <section class="container py-5" id="gallery">
+    <section class="container py-5" id="gallery" aria-label="Galería">
         <h2 class="text-center mb-4">Galería</h2>
-        <div class="row g-3">
-            <div class="col-6 col-md-4">
-                <a href="/terrazzo/assets/venue1.jpg" class="glightbox" data-gallery="terrazzo">
-                    <img src="/terrazzo/assets/venue1.jpg" alt="" class="gallery-img">
-                </a>
-            </div>
-            <div class="col-6 col-md-4">
-                <a href="/terrazzo/assets/venue2.jpg" class="glightbox" data-gallery="terrazzo">
-                    <img src="/terrazzo/assets/venue2.jpg" alt="" class="gallery-img">
-                </a>
-            </div>
-            <div class="col-6 col-md-4">
-                <a href="/terrazzo/assets/venue3.jpg" class="glightbox" data-gallery="terrazzo">
-                    <img src="/terrazzo/assets/venue3.jpg" alt="" class="gallery-img">
-                </a>
-            </div>
-            <!-- repeat ... -->
+        <div id="gallery-carousel" class="gallery-carousel" role="region" aria-roledescription="carousel" aria-label="Fotos del lugar">
+            <!-- slides injected by JS -->
         </div>
     </section>
 
@@ -640,8 +678,54 @@
         /* ===== Lightbox ===== */
         const lightbox = GLightbox({ selector: '.glightbox' });
 
+        // ===== Build Gallery slides and init Flickity + GLightbox =====
+        (function initGalleryCarousel(){
+            const container = document.getElementById('gallery-carousel');
+            if (!container) return;
 
+            // 1) Build the image list: venue1.jpg ... venue9.jpg
+            const sources = Array.from({ length: 9 }, (_, i) => `/terrazzo/assets/venue${i+1}.jpg`);
 
+            // 2) Inject cells: <div class="carousel-cell"><a class="glightbox" ...><img /></a></div>
+            container.innerHTML = sources.map((src, idx) => `
+                <div class="carousel-cell">
+                  <a href="${src}" class="glightbox" data-gallery="terrazzo" aria-label="Abrir imagen ${idx+1} de 9">
+                    <img src="${src}" alt="Terrazzo — vista del lugar ${idx+1}" loading="lazy" decoding="async">
+                  </a>
+                </div>
+            `).join('');
+
+            // 3) Init Flickity (responsive groupCells via function)
+            const flkty = new Flickity(container, {
+                cellSelector: '.carousel-cell',
+                cellAlign: 'center',
+                contain: true,
+                wrapAround: true,
+                imagesLoaded: true,
+                // Lazy-load next/prev image candidates (works with data-flickity-lazyload; we’re just using browser lazy="lazy" here)
+                pageDots: true,
+                prevNextButtons: true,           // will be hidden on small screens below
+                draggable: true,
+                groupCells: function(width){
+                    if (width < 576) return 1;     // mobile
+                    if (width < 992) return 2;     // tablet
+                    return 3;                      // desktop+
+                }
+            });
+
+            // Hide arrows on small screens (keeps dots)
+            const mqSmall = window.matchMedia('(max-width: 575.98px)');
+            function toggleArrows(e){ flkty.options.prevNextButtons = !e.matches; flkty.updateSize(); }
+            mqSmall.addEventListener ? mqSmall.addEventListener('change', toggleArrows) : mqSmall.addListener(toggleArrows);
+            toggleArrows(mqSmall);
+
+            // 4) (Re)bind GLightbox now that slides exist
+            if (window.GLightbox) {
+                // If you already have a GLightbox instance, destroy/recreate to pick up new anchors.
+                if (window.__galleryLightbox) { try { window.__galleryLightbox.destroy(); } catch(e){} }
+                window.__galleryLightbox = GLightbox({ selector: '#gallery-carousel .glightbox' });
+            }
+        })();
 
     </script>
 


### PR DESCRIPTION
## Summary
- convert static gallery grid into Flickity carousel
- style gallery carousel and make slides responsive
- build slides dynamically and hook up Flickity + GLightbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d04c57388332b5d5da898ad93200