### PR TITLE
Load Flickity synchronously and guard carousel setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,7 +441,15 @@
 ================================================= -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/flickity@2/dist/flickity.pkgd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flickity@2/dist/flickity.pkgd.min.js"></script>
+
+    <script>
+        // run cb only when Flickity is available; safe to call multiple times
+        function onFlickityReady(cb){
+            if (window.Flickity) { cb(); return; }
+            window.addEventListener('load', cb, { once: true });
+        }
+    </script>
 
 
     <script>
@@ -601,6 +609,7 @@
 
         /* helper: enable or destroy carousels when we cross break-points */
         function syncCarousels() {
+            if (!window.Flickity) return;  // library not ready yet
             const isMobile = window.matchMedia('(max-width: 767.98px)').matches;
 
             [menuGrid, eventGrid].forEach(grid => {
@@ -646,7 +655,7 @@
                 buildEventCards(ev);
             })
         ]).then(() => {
-            syncCarousels();
+            onFlickityReady(syncCarousels);
             // force-run our height-equaliser immediately
             equaliseCardHeights(menuGrid);
             equaliseCardHeights(eventGrid);
@@ -671,23 +680,21 @@
         const lightbox = GLightbox({ selector: '.glightbox' });
 
         // ===== Build Gallery slides and init Flickity + GLightbox =====
-        (function initGalleryCarousel(){
+        function initGalleryCarousel(){
             const container = document.getElementById('gallery-carousel');
             if (!container) return;
 
-            // 1) Build the image list: venue1.jpg ... venue9.jpg
+            // venue1.jpg … venue9.jpg
             const sources = Array.from({ length: 9 }, (_, i) => `/terrazzo/assets/venue${i+1}.jpg`);
 
-            // 2) Inject cells: <div class="carousel-cell"><a class="glightbox" ...><img /></a></div>
             container.innerHTML = sources.map((src, idx) => `
-                <div class="carousel-cell">
-                  <a href="${src}" class="glightbox" data-gallery="terrazzo" aria-label="Abrir imagen ${idx+1} de 9">
-                    <img src="${src}" alt="Terrazzo — vista del lugar ${idx+1}" loading="lazy" decoding="async">
-                  </a>
-                </div>
-            `).join('');
+      <div class="carousel-cell">
+        <a href="${src}" class="glightbox" data-gallery="terrazzo" aria-label="Abrir imagen ${idx+1} de 9">
+          <img src="${src}" alt="Terrazzo — vista del lugar ${idx+1}" loading="lazy" decoding="async">
+        </a>
+      </div>
+    `).join('');
 
-            // 3) Init Flickity (responsive groupCells via function)
             const flkty = new Flickity(container, {
                 cellSelector: '.carousel-cell',
                 cellAlign: 'center',
@@ -695,27 +702,29 @@
                 wrapAround: true,
                 imagesLoaded: true,
                 pageDots: true,
-                prevNextButtons: true,   // will be toggled off on small screens
+                prevNextButtons: true,
                 draggable: true,
                 groupCells: function(width){
-                    if (width < 576) return 1;  // mobile
-                    if (width < 992) return 2;  // tablet
-                    return 3;                   // desktop+
+                    if (width < 576) return 1;   // mobile
+                    if (width < 992) return 2;   // tablet
+                    return 3;                    // desktop+
                 }
             });
 
-            // Hide arrows on small screens (keeps dots)
+            // hide arrows on very small screens, keep dots
             const mqSmall = window.matchMedia('(max-width: 575.98px)');
             function toggleArrows(e){ flkty.options.prevNextButtons = !e.matches; flkty.updateSize(); }
             mqSmall.addEventListener ? mqSmall.addEventListener('change', toggleArrows) : mqSmall.addListener(toggleArrows);
             toggleArrows(mqSmall);
 
-            // 4) (Re)bind GLightbox now that slides exist
+            // re-bind GLightbox now that slides exist
             if (window.GLightbox) {
                 if (window.__galleryLightbox) { try { window.__galleryLightbox.destroy(); } catch(e){} }
                 window.__galleryLightbox = GLightbox({ selector: '#gallery-carousel .glightbox' });
             }
-        })();
+        }
+
+        onFlickityReady(initGalleryCarousel);
 
     </script>
 


### PR DESCRIPTION
## Summary
- Load Flickity script synchronously and add `onFlickityReady` helper
- Guard `syncCarousels` and invoke it only when Flickity is ready
- Refactor gallery carousel initialization to wait for Flickity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d81b8a6c8332a5921a883f6cd093