### PR TITLE
Add fixed aspect-ratio wrapper to gallery carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,57 +268,32 @@
 
 
         /* ===== Gallery carousel (Flickity) ===== */
-        .gallery-carousel {
-            /* Flickity will add .flickity-enabled */
-        }
-        .gallery-carousel .carousel-cell {
-            width: 80%;
-            margin: 0 .75rem;
-        }
-        .gallery-carousel .carousel-cell a {
-            display: block;
-            overflow: hidden;
-            border-radius: .5rem;
-        }
-        .gallery-carousel .carousel-cell img {
-            display: block;
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-        }
-        .gallery-carousel .flickity-page-dots {
-            margin-top: 1rem;
-        }
-        .gallery-carousel .flickity-page-dots .dot {
-            width: 8px;
-            height: 8px;
-            margin: 0 4px;
-            opacity: .4;
-        }
-        .gallery-carousel .flickity-page-dots .dot.is-selected {
-            opacity: 1;
+        .gallery-carousel .carousel-cell { width: 80%; margin: 0 .75rem; }
+        @media (min-width: 576px) { .gallery-carousel .carousel-cell { width: 45%; } }
+        @media (min-width: 992px) { .gallery-carousel .carousel-cell { width: 30%; } }
+        @media (min-width: 1200px){ .gallery-carousel .carousel-cell { width: 28%; } }
+
+        /* Fixed-height frame so every slide is uniform */
+        .gallery-carousel .carousel-frame{
+          width: 100%;
+          aspect-ratio: 4 / 3;            /* pick 16/9 if you prefer wider */
+          border-radius: .5rem;
+          overflow: hidden;
+          background: #0e123b;            /* subtle placeholder color */
         }
 
-        /* Tablet: 2-up */
-        @media (min-width: 576px) {
-            .gallery-carousel .carousel-cell {
-                width: 45%;
-            }
+        /* Image fills the frame cleanly */
+        .gallery-carousel .carousel-frame img{
+          display: block;
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
         }
 
-        /* Desktop: 3-up */
-        @media (min-width: 992px) {
-            .gallery-carousel .carousel-cell {
-                width: 30%;
-            }
-        }
-
-        /* Large desktop: slightly tighter */
-        @media (min-width: 1200px) {
-            .gallery-carousel .carousel-cell {
-                width: 28%;
-            }
-        }
+        /* Dots (keep your brand look) */
+        .gallery-carousel .flickity-page-dots{ margin-top: 1rem; }
+        .gallery-carousel .flickity-page-dots .dot{ width: 8px; height: 8px; margin: 0 4px; opacity: .4; }
+        .gallery-carousel .flickity-page-dots .dot.is-selected{ opacity: 1; }
     </style>
 </head>
 
@@ -688,12 +663,18 @@
             const sources = Array.from({ length: 9 }, (_, i) => `/terrazzo/assets/venue${i+1}.jpg`);
 
             container.innerHTML = sources.map((src, idx) => `
-      <div class="carousel-cell">
-        <a href="${src}" class="glightbox" data-gallery="terrazzo" aria-label="Abrir imagen ${idx+1} de 9">
-          <img src="${src}" alt="Terrazzo — vista del lugar ${idx+1}" loading="lazy" decoding="async">
-        </a>
+  <div class="carousel-cell">
+    <a href="${src}" class="glightbox" data-gallery="terrazzo" aria-label="Abrir imagen ${idx+1} de ${sources.length}">
+      <div class="carousel-frame">
+        <img src="${src}" alt="Terrazzo — vista del lugar ${idx+1}" loading="lazy" decoding="async">
       </div>
-    `).join('');
+    </a>
+  </div>
+`).join('');
+
+            // IMPORTANT: re-bind GLightbox now that slides exist
+            if (window.galleryLightbox) { window.galleryLightbox.destroy(); }
+            window.galleryLightbox = GLightbox({ selector: '.glightbox' });
 
             const flkty = new Flickity(container, {
                 cellSelector: '.carousel-cell',
@@ -710,6 +691,7 @@
                     return 3;                    // desktop+
                 }
             });
+            flkty.resize(); // ensure correct height on first paint
 
             // hide arrows on very small screens, keep dots
             const mqSmall = window.matchMedia('(max-width: 575.98px)');
@@ -717,11 +699,6 @@
             mqSmall.addEventListener ? mqSmall.addEventListener('change', toggleArrows) : mqSmall.addListener(toggleArrows);
             toggleArrows(mqSmall);
 
-            // re-bind GLightbox now that slides exist
-            if (window.GLightbox) {
-                if (window.__galleryLightbox) { try { window.__galleryLightbox.destroy(); } catch(e){} }
-                window.__galleryLightbox = GLightbox({ selector: '#gallery-carousel .glightbox' });
-            }
         }
 
         onFlickityReady(initGalleryCarousel);


### PR DESCRIPTION
## Summary
- Ensure uniform gallery slides with fixed aspect ratio and frame
- Re-bind GLightbox when gallery slides are injected
- Call Flickity resize after initialization for accurate sizing

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6895dd1c8b088332b45363ad9b3444f2