### PR TITLE
Add sales demo readiness packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The `_incoming/` folder is gitignored because raw images are usually heavy and a
 
 En este MVP estático, el contenido principal se mantiene desde archivos JSON estructurados. Esto permite actualizar menú, eventos y galería sin cambiar la lógica del sitio. En una versión pagada o completa, esta misma estructura puede convertirse en un panel Admin para que una persona no técnica actualice menú, eventos y galería sin tocar código.
 
-Antes de una demo, grabación o entrega de avance, usar el [checklist manual de QA y demo](docs/demo-qa-checklist.md) para revisar desktop, mobile y el flujo de pedido por WhatsApp.
+Antes de una demo, grabación o entrega de avance, usar el [checklist manual de QA y demo](docs/demo-qa-checklist.md) para revisar desktop, mobile y el flujo de pedido por WhatsApp. Para presentar el MVP al owner sin abrir preguntas prematuras de pagos o backend, revisar el [paquete de preparación para demo comercial](docs/sales-demo-readiness.md).
 
 Para pagos en línea futuros, revisar el [plan de arquitectura de pagos](docs/payment-architecture-plan.md) y la [investigación de proveedor de pagos](docs/payment-provider-research.md). Son documentos de planeación y no funcionalidades implementadas en el MVP actual.
 

--- a/docs/sales-demo-readiness.md
+++ b/docs/sales-demo-readiness.md
@@ -1,0 +1,108 @@
+# Paquete de preparación para demo comercial
+
+Guía práctica para presentar el MVP de Terrazzo Urban Food & Drinks al owner. La prioridad es mostrar valor de negocio primero: una experiencia moderna, clara y lista para que el cliente imagine cómo ayudaría al restaurante.
+
+## 1. Objetivo de la demo
+
+La demo no debe empezar con preguntas técnicas ni con decisiones de pagos, backend o administración. El primer objetivo es que el owner vea un MVP pulido, entienda cómo se vería Terrazzo en línea y perciba valor para el negocio.
+
+Las preguntas profundas vienen después, solo si muestra interés. Primero se vende la visión: mejor presencia digital, menú mobile-friendly, pedidos por WhatsApp, eventos, promociones y una imagen más profesional.
+
+## 2. Qué mostrar primero
+
+Orden recomendado para la demo:
+
+1. Hero e impresión de marca: abrir con la primera vista, el estilo urbano y la sensación general del lugar.
+2. Menú y categorías: mostrar cómo una persona puede explorar hamburguesas, alitas, jochos, nachos y coctelería.
+3. Flujo de carrito: agregar productos y mostrar que el pedido se arma de forma simple.
+4. Mensaje de pedido por WhatsApp: enseñar el mensaje con detalle, total estimado y texto de confirmación.
+5. Eventos & Deportes: mostrar que el sitio también sirve para promos, partidos y fechas especiales.
+6. Galería/lightbox: abrir fotos para comunicar ambiente, comida y experiencia.
+7. Contacto/mapa: cerrar con ubicación y facilidad para llegar o contactar.
+8. Mantenimiento de contenido: mencionarlo brevemente como ventaja, sin convertirlo en tema técnico.
+
+## 3. Qué decir durante la demo
+
+Guion natural en español:
+
+> "La idea de este MVP es que Terrazzo tenga una presencia digital más fuerte y más fácil de usar desde celular. Cuando alguien entra, primero ve la marca, el ambiente y una propuesta clara: food, drinks, eventos y deportes en un solo lugar."
+
+> "Aquí el cliente puede revisar el menú por categorías, sin tener que buscar fotos sueltas o preguntar todo por mensaje. Puede agregar productos al carrito y mandar el pedido por WhatsApp con el detalle ya armado, lo que reduce vueltas y hace más fácil tomar el pedido."
+
+> "También dejamos espacio para eventos, promos y transmisiones deportivas, porque eso ayuda a mover visitas en días específicos. La galería sirve para vender el ambiente del lugar, no solo la comida."
+
+> "En esta etapa el objetivo es validar que la experiencia le haga sentido al negocio. Si le ves valor, después podemos hablar de si conviene dejarlo como sitio informativo, sumarle pagos en línea, o convertirlo en una aplicación más completa con administración."
+
+La energía debe ser segura y tranquila. Evita sonar como si estuvieras pidiendo permiso para todo. Preséntalo como una propuesta concreta que ya permite imaginar el resultado.
+
+## 4. Qué no decir demasiado temprano
+
+- No empezar hablando de backend, admin, Mercado Pago, serverless, credenciales o mantenimiento.
+- No preguntar si quiere pagos en línea antes de que reaccione al MVP.
+- No sobreexplicar limitaciones si no las pregunta.
+- No hacerlo sonar incompleto o como "solo una prueba".
+- No ofrecer demasiadas features futuras al mismo tiempo.
+
+## 5. Si el owner muestra interés
+
+Cuando ya vea valor, entonces sí conviene abrir preguntas de alcance:
+
+- Si quiere solo un sitio web o una aplicación web más completa.
+- Si los pagos en línea son importantes para su operación.
+- Si necesita panel admin o gestión de pedidos.
+- Si las actualizaciones de contenido las haría Diego o alguien del staff.
+- Si le interesa mantenimiento mensual.
+- Qué timeline y presupuesto tiene en mente.
+
+Estas preguntas deben sentirse como una siguiente etapa natural, no como presión.
+
+## 6. Si el owner dice "tal vez"
+
+- Preguntar qué haría el sitio más útil para Terrazzo.
+- Proponer un siguiente paso pequeño, como revisar una versión ajustada o compartir el link para que lo vea con calma.
+- No descontar inmediatamente.
+- Enviar un follow-up corto por WhatsApp con el link de la demo y beneficios principales.
+
+Ejemplo de respuesta:
+
+> "Perfecto, tiene sentido verlo con calma. Lo importante para mí sería saber qué parte te parece más útil y qué faltaría para que esto sí le aporte al negocio."
+
+## 7. Si el owner dice que no
+
+- Mantener la conversación profesional y tranquila.
+- Preguntar si puedes darle seguimiento más adelante.
+- Usar su feedback para mejorar el pitch.
+- No discutir ni intentar forzar la venta.
+
+Ejemplo de cierre:
+
+> "Gracias por verlo. Me sirve mucho tu feedback. Si en algún momento quieres retomarlo o probar una versión más enfocada a promos, menú o pedidos, con gusto lo revisamos."
+
+## 8. Puntos de valor del MVP
+
+- Presencia visual moderna para Terrazzo.
+- Menú mobile-friendly y fácil de explorar.
+- Flujo de pedido por WhatsApp.
+- Promoción de eventos, deportes y promos.
+- Galería para vender ambiente y experiencia.
+- Estructura de contenido mantenible.
+- Base lista para pagos o admin si el negocio decide crecer hacia eso.
+
+## 9. Limitaciones conocidas y cómo decirlas
+
+- Pagos: "Los pagos en línea están planeados como siguiente etapa, pero no están activos todavía. Para este MVP dejamos un flujo práctico por WhatsApp y transferencia."
+- Admin: "El panel administrativo se puede agregar después si hace sentido que el staff actualice menú, eventos o pedidos directamente."
+- Contenido JSON: "Por ahora el contenido vive en archivos estructurados, lo que mantiene el costo más bajo y permite actualizar menú, eventos y galería sin rehacer el sitio."
+- WhatsApp + transferencia: "Lo dejamos así intencionalmente porque es una forma práctica de validar pedidos sin meter complejidad antes de saber si el MVP le conviene al negocio."
+
+La clave es hablar de estas limitaciones como decisiones de alcance, no como fallas.
+
+## 10. Plantilla de follow-up por WhatsApp
+
+Hola, gracias por darte el tiempo de ver la demo de Terrazzo. Te comparto el link para que la revises con calma:
+
+[link de la demo]
+
+La propuesta busca darle a Terrazzo una presencia más moderna, menú fácil de usar en celular, pedidos por WhatsApp, espacio para eventos/promos y una galería que venda mejor el ambiente del lugar.
+
+Si te hace sentido, el siguiente paso sería definir si lo dejamos como sitio web práctico o si conviene crecerlo después con pagos en línea, admin o mantenimiento mensual.


### PR DESCRIPTION
Summary:
- Added a sales/demo readiness packet for presenting the MVP to the owner.
- Clarified what to show, what to say, what not to ask too early, and how to handle owner reactions.
- Added a follow-up message template.

Validation:
- [ ] Markdown renders clearly
- [x] README links to sales/demo readiness doc
- [x] npm run validate:content
- [x] No site behavior/content changed

Notes:
- Documentation-only PR.
- No payment, backend, admin, SDK, credential, UI, or content changes are included.