### PR TITLE
Fix cart button overlap in drawer

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -258,8 +258,14 @@
           border: none; border-radius: 999px; padding: 0.75rem 1rem;
           box-shadow: 0 10px 24px rgba(0,0,0,.35);
           display: flex; align-items: center; gap: .5rem; font-weight: 700;
+          transition: opacity .2s ease, transform .2s ease, background-color .2s ease, color .2s ease;
         }
         .cart-fab:hover { background: var(--plasma-magenta); color:#fff; }
+        body.cart-drawer-open .cart-fab {
+          opacity: 0;
+          pointer-events: none;
+          transform: translateY(0.5rem);
+        }
 
         .cart-count-badge{
           min-width: 1.6rem; height: 1.6rem; border-radius: 999px;
@@ -289,4 +295,3 @@
           font-weight:700; border:0; padding:.75rem 1rem; border-radius:.5rem;
         }
         .cart-checkout-btn:hover { background: var(--plasma-magenta); color:#fff; }
-

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -147,6 +147,16 @@
         const cartLinesEl = document.getElementById('cartLines');
         const cartTotalEl = document.getElementById('cartTotal');
         const checkoutBtn  = document.getElementById('checkoutBtn');
+        const cartDrawerEl = document.getElementById('cartDrawer');
+
+        if(cartDrawerEl){
+          cartDrawerEl.addEventListener('show.bs.offcanvas', () => {
+            document.body.classList.add('cart-drawer-open');
+          });
+          cartDrawerEl.addEventListener('hidden.bs.offcanvas', () => {
+            document.body.classList.remove('cart-drawer-open');
+          });
+        }
 
         function renderCart(){
           const {items, total} = cartTotals();


### PR DESCRIPTION
Summary:
- Hid the floating cart button while the cart drawer is open.
- Prevented the cart FAB from overlapping checkout/helper text.
- Preserved cart behavior, counts, and WhatsApp checkout.

Validation:
- [x] npm run validate:content
- [ ] Floating cart button hides when drawer opens
- [ ] Floating cart button returns when drawer closes
- [ ] Empty cart drawer has no overlap
- [ ] Cart with items has no overlap
- [ ] WhatsApp checkout still works
- [ ] No desktop/mobile layout regression

Notes:
- Small visual bugfix only.
- No content, payment, backend, admin, or checkout-message changes.